### PR TITLE
Implement Next.js portfolio

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,10 @@
+FROM gitpod/workspace-full
+                    
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && #     sudo apt-get install -yq bastet && #     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: echo "Replace me with a build script for the project."
+    command: echo "Replace me with something that should run on every start, or just
+      remove me entirely."
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Henrique Gonçalves Portfolio
 
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/henriquetgoncalves/portifolio)
+
 A Next.js + Tailwind CSS portfolio showcasing Henrique's projects, blog and interests. Bilingual (Português/English).
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Henrique Gonçalves Portfolio
+
+A Next.js + Tailwind CSS portfolio showcasing Henrique's projects, blog and interests. Bilingual (Português/English).
+
+## Install
+
+```bash
+npm install
+npm run dev
+```
+
+Build for production:
+
+```bash
+npm run build && npm start
+```
+
+## Features
+
+- Hero and About sections
+- Skills grid
+- Project cards
+- MDX blog
+- Crypto price widget
+- Fitness progress chart
+- Travel gallery
+- Contact form
+- Dark/light theme toggle

--- a/components/About.jsx
+++ b/components/About.jsx
@@ -1,0 +1,19 @@
+export default function About() {
+  return (
+    <section id="about" className="py-10 max-w-3xl mx-auto">
+      <h3 className="text-2xl font-semibold mb-4">About Me</h3>
+      <p className="mb-2">
+        Sou Henrique, desenvolvedor full-stack apaixonado por Python, Flask e
+        JavaScript. Criei uma API de transcrição do YouTube com Docker e Redis,
+        atualmente avaliando implantações no Heroku ou Render.
+      </p>
+      <p className="mb-2">
+        Fascinado por blockchain e DeFi (Orca, Uniswap), desenvolvo ferramentas
+        para rastrear portfolios e operações cripto. Entre um pull request e
+        outro, estou provavelmente treinando CrossFit ou planejando a próxima
+        viagem ao redor do mundo.
+      </p>
+      <p className="text-sm italic">*Piada interna: este código levanta mais do que meu deadlift*</p>
+    </section>
+  );
+}

--- a/components/ContactForm.jsx
+++ b/components/ContactForm.jsx
@@ -1,0 +1,34 @@
+export default function ContactForm() {
+  return (
+    <form
+      action="https://formspree.io/f/mayvlgyy"
+      method="POST"
+      className="max-w-md mx-auto p-4 space-y-2"
+      id="contact"
+    >
+      <input
+        type="text"
+        name="name"
+        placeholder="Name"
+        className="w-full p-2 border rounded"
+        required
+      />
+      <input
+        type="email"
+        name="email"
+        placeholder="Email"
+        className="w-full p-2 border rounded"
+        required
+      />
+      <textarea
+        name="message"
+        placeholder="Message"
+        className="w-full p-2 border rounded"
+        required
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
+        Send
+      </button>
+    </form>
+  );
+}

--- a/components/CryptoWidget.jsx
+++ b/components/CryptoWidget.jsx
@@ -1,0 +1,24 @@
+import useSWR from 'swr';
+import { LineChart, Line, ResponsiveContainer } from 'recharts';
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+export default function CryptoWidget() {
+  const { data } = useSWR(
+    'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1',
+    fetcher,
+    { refreshInterval: 60000 }
+  );
+  const prices = data?.prices?.map(([t, p]) => ({ t, p })) || [];
+  return (
+    <div className="max-w-sm mx-auto my-10">
+      <h3 className="font-bold mb-2 text-center">BTC Price (24h)</h3>
+      <ResponsiveContainer width="100%" height={100}>
+        <LineChart data={prices}>
+          <Line dataKey="p" stroke="#f7931a" dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+      <p className="text-xs text-center">Powered by public CoinGecko API</p>
+    </div>
+  );
+}

--- a/components/FitnessChart.jsx
+++ b/components/FitnessChart.jsx
@@ -1,0 +1,23 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis } from 'recharts';
+
+const data = [
+  { day: 'Day 1', weight: 70, pr: 300 },
+  { day: 'Day 30', weight: 70, pr: 320 },
+  { day: 'Day 60', weight: 70, pr: 345 },
+];
+
+export default function FitnessChart() {
+  return (
+    <div className="max-w-md mx-auto my-10" id="fitness">
+      <h3 className="font-bold mb-2 text-center">CrossFit Progress</h3>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data}>
+          <XAxis dataKey="day" />
+          <YAxis />
+          <Line dataKey="pr" stroke="#4ade80" />
+        </LineChart>
+      </ResponsiveContainer>
+      <p className="text-xs text-center">Always chasing that 350 lbs deadlift.</p>
+    </div>
+  );
+}

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,0 +1,15 @@
+export default function Footer() {
+  return (
+    <footer className="text-center py-4 border-t mt-10">
+      <div className="space-x-4 mb-2">
+        <a href="https://linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
+        <a href="https://github.com" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://twitter.com" target="_blank" rel="noreferrer">Twitter</a>
+        <a href="https://t.me" target="_blank" rel="noreferrer">Telegram</a>
+        <a href="mailto:henrique.develop@hotmail.com">Email</a>
+      </div>
+      <p className="text-xs">Languages: Portuguese (native), English (in progress).</p>
+      <p className="mt-2">© 2025 Henrique Gonçalves. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/components/Gallery.jsx
+++ b/components/Gallery.jsx
@@ -1,0 +1,20 @@
+const images = [
+  { src: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e', alt: 'Orlando theme parks' },
+  { src: 'https://images.unsplash.com/photo-1530092285049-1c42085fd395', alt: 'Nordeste trip' },
+  { src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470', alt: 'Coming soon' },
+];
+
+export default function Gallery() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 py-10" id="gallery">
+      {images.map((img) => (
+        <img
+          key={img.alt}
+          src={img.src}
+          alt={img.alt}
+          className="object-cover w-full h-48 transform hover:scale-105 transition"
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import { useTheme } from './ThemeContext';
+
+export default function Header() {
+  const { toggle } = useTheme();
+  return (
+    <header className="flex justify-between items-center p-4">
+      <h1 className="text-2xl font-bold">Henrique Gonçalves</h1>
+      <nav className="space-x-4">
+        <Link href="#about" className="hover:underline">About</Link>
+        <Link href="#projects" className="hover:underline">Projects</Link>
+        <Link href="/blog" className="hover:underline">Blog</Link>
+        <button
+          onClick={toggle}
+          className="ml-4 px-2 py-1 border rounded"
+        >
+          Toggle
+        </button>
+      </nav>
+    </header>
+  );
+}

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -1,0 +1,18 @@
+import { motion } from 'framer-motion';
+
+export default function Hero() {
+  return (
+    <section className="text-center py-20" id="hero">
+      <motion.h2
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.7 }}
+        className="text-4xl font-bold mb-4"
+      >
+        Henrique Gonçalves
+      </motion.h2>
+      <p className="mb-2">Full-Stack Developer, Crypto Enthusiast, CrossFit Athlete</p>
+      <p className="italic">Transforming ideas into code, one block at a time.</p>
+    </section>
+  );
+}

--- a/components/ProjectCard.jsx
+++ b/components/ProjectCard.jsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion';
+
+export default function ProjectCard({ title, desc, tech, link }) {
+  return (
+    <motion.div
+      whileHover={{ scale: 1.05 }}
+      className="border rounded p-4 shadow"
+    >
+      <h4 className="font-bold mb-2">{title}</h4>
+      <p className="text-sm mb-2">{desc}</p>
+      <p className="text-xs mb-2">{tech.join(', ')}</p>
+      <a href={link} className="text-blue-500 underline" target="_blank" rel="noreferrer">GitHub</a>
+    </motion.div>
+  );
+}

--- a/components/SkillsGrid.jsx
+++ b/components/SkillsGrid.jsx
@@ -1,0 +1,28 @@
+const skills = {
+  Languages: ['JavaScript', 'TypeScript', 'Python', 'HTML', 'CSS'],
+  Frameworks: ['React', 'Next.js', 'Flask'],
+  DevOps: ['Docker', 'Redis', 'GitHub', 'GitHub Actions'],
+  Blockchain: ['Solidity', 'Web3.js', 'Hardhat', 'Uniswap', 'Orca'],
+  Testing: ['Jest', 'pytest', 'Cypress'],
+  Other: ['Tailwind CSS', 'Node.js', 'PostgreSQL', 'GraphQL', 'Serverless'],
+};
+
+export default function SkillsGrid() {
+  return (
+    <section className="py-10" id="skills">
+      <h3 className="text-2xl font-semibold mb-4 text-center">Skills</h3>
+      <div className="grid md:grid-cols-3 gap-4">
+        {Object.entries(skills).map(([category, list]) => (
+          <div key={category} className="border p-4 rounded">
+            <h4 className="font-bold mb-2">{category}</h4>
+            <ul className="space-y-1">
+              {list.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/ThemeContext.jsx
+++ b/components/ThemeContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) setTheme(stored);
+    document.documentElement.classList.toggle('dark', stored === 'dark');
+  }, []);
+
+  const toggle = () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+const withMDX = require('@next/mdx')({
+  extension: /\.mdx?$/,
+});
+module.exports = withMDX({
+  pageExtensions: ['js', 'jsx', 'mdx'],
+  images: {
+    domains: ['images.unsplash.com'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "henrique-portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-mdx-remote": "^4.3.0",
+    "remark-gfm": "^3.0.1",
+    "tailwindcss": "^3.3.2",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "framer-motion": "^10.12.16",
+    "recharts": "^2.5.0",
+    "swr": "^2.0.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,10 @@
+import '../styles.css';
+import { ThemeProvider } from '../components/ThemeContext';
+
+export default function App({ Component, pageProps }) {
+  return (
+    <ThemeProvider>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}

--- a/pages/blog/[slug].jsx
+++ b/pages/blog/[slug].jsx
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { MDXRemote } from 'next-mdx-remote';
+import { serialize } from 'next-mdx-remote/serialize';
+import remarkGfm from 'remark-gfm';
+
+export async function getStaticPaths() {
+  const files = fs.readdirSync(path.join('posts'));
+  const paths = files.map((file) => ({ params: { slug: file.replace('.mdx', '') } }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params: { slug } }) {
+  const source = fs.readFileSync(path.join('posts', slug + '.mdx'), 'utf-8');
+  const { data, content } = matter(source);
+  const mdxSource = await serialize(content, { mdxOptions: { remarkPlugins: [remarkGfm] } });
+  return { props: { frontMatter: data, mdxSource } };
+}
+
+export default function PostPage({ frontMatter, mdxSource }) {
+  return (
+    <article className="prose mx-auto py-10">
+      <h1>{frontMatter.title}</h1>
+      <MDXRemote {...mdxSource} />
+    </article>
+  );
+}

--- a/pages/blog/index.jsx
+++ b/pages/blog/index.jsx
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+import matter from 'gray-matter';
+
+export async function getStaticProps() {
+  const files = fs.readdirSync(path.join('posts'));
+  const posts = files.map((file) => {
+    const slug = file.replace('.mdx', '');
+    const source = fs.readFileSync(path.join('posts', file), 'utf-8');
+    const { data } = matter(source);
+    return { slug, ...data };
+  });
+  return { props: { posts } };
+}
+
+export default function Blog({ posts }) {
+  return (
+    <div className="max-w-3xl mx-auto py-10">
+      <h1 className="text-3xl font-bold mb-6">Blog</h1>
+      <ul className="space-y-4">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link href={`/blog/${post.slug}`} className="text-blue-500 underline">
+              {post.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,0 +1,56 @@
+import Head from 'next/head';
+import Header from '../components/Header';
+import Hero from '../components/Hero';
+import About from '../components/About';
+import SkillsGrid from '../components/SkillsGrid';
+import CryptoWidget from '../components/CryptoWidget';
+import FitnessChart from '../components/FitnessChart';
+import Gallery from '../components/Gallery';
+import ContactForm from '../components/ContactForm';
+import Footer from '../components/Footer';
+import ProjectCard from '../components/ProjectCard';
+
+const projects = [
+  {
+    title: 'YouTube Transcription API',
+    desc: 'Flask API that ingests YouTube URLs and converts audio to text.',
+    tech: ['Flask', 'Docker', 'Redis', 'Python'],
+    link: 'https://github.com/henrique/youtube-transcription',
+  },
+  {
+    title: 'Crypto Portfolio Tracker',
+    desc: 'Dashboard to track trades and P/L over time.',
+    tech: ['Python', 'Pandas', 'Plotly'],
+    link: 'https://github.com/henrique/crypto-tracker',
+  },
+  {
+    title: 'CrossFit Performance Dashboard',
+    desc: 'Interactive dashboard to log WODs and PRs.',
+    tech: ['React', 'Next.js', 'Chart.js'],
+    link: 'https://github.com/henrique/crossfit-dashboard',
+  },
+];
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Henrique Gonçalves</title>
+      </Head>
+      <Header />
+      <Hero />
+      <About />
+      <SkillsGrid />
+      <section id="projects" className="py-10 grid md:grid-cols-3 gap-4">
+        {projects.map((p) => (
+          <ProjectCard key={p.title} {...p} />
+        ))}
+      </section>
+      <CryptoWidget />
+      <FitnessChart />
+      <Gallery />
+      <ContactForm />
+      <Footer />
+    </>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/posts/criptolucro.mdx
+++ b/posts/criptolucro.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Como rastrear lucros em operações de criptomoedas'
+---
+
+Rastrear lucros em exchanges como Binance ou PancakeSwap pode ser complicado.
+Use planilhas ou ferramentas customizadas para centralizar suas transações e
+visualizar P/L ao longo do tempo.

--- a/posts/deadlift.mdx
+++ b/posts/deadlift.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Improving CrossFit deadlift form'
+---
+
+Consistency and mobility are key. Keep your back straight and engage the core.
+Aim to beat that 345 lbs PR soon!

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './pages/**/*.{js,jsx,mdx}',
+    './components/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        mono: ['Roboto Mono', 'monospace'],
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- build Next.js portfolio with Tailwind CSS
- add hero, about, skills, projects, blog, crypto widget, fitness chart, gallery and contact form
- add MDX blog posts
- implement theme toggle and social links

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683f5245c4948321acfd8ac5b25d06e0